### PR TITLE
Support Android 11

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,7 +11,7 @@ android {
     namespace = "com.yuk.miuiHomeR"
     defaultConfig {
         applicationId = namespace
-        minSdk = 31
+        minSdk = 30
         targetSdk = 33
         versionCode = 12
         versionName = "1.0.3" + (getGitHeadRefsSuffix(rootProject))

--- a/app/src/main/java/com/yuk/miuiHomeR/MainHook.kt
+++ b/app/src/main/java/com/yuk/miuiHomeR/MainHook.kt
@@ -57,7 +57,7 @@ class MainHook : IXposedHookLoadPackage, IXposedHookZygoteInit /* Optional */ {
                         AppDrawer,
                         Recent,
                     )
-                    if (isLegacyAndroid()) {
+                    if (!isLegacyAndroid()) {
                         initHooks(
                             Dock,
                             EnableFolderIconBlur,

--- a/app/src/main/java/com/yuk/miuiHomeR/MainHook.kt
+++ b/app/src/main/java/com/yuk/miuiHomeR/MainHook.kt
@@ -11,6 +11,7 @@ import com.yuk.miuiHomeR.utils.Helpers
 import com.yuk.miuiHomeR.utils.PrefsMap
 import com.yuk.miuiHomeR.utils.PrefsUtils
 import com.yuk.miuiHomeR.utils.ktx.hookBeforeMethod
+import com.yuk.miuiHomeR.utils.ktx.isLegacyAndroid
 import de.robv.android.xposed.IXposedHookLoadPackage
 import de.robv.android.xposed.IXposedHookZygoteInit
 import de.robv.android.xposed.XSharedPreferences
@@ -44,9 +45,7 @@ class MainHook : IXposedHookLoadPackage, IXposedHookZygoteInit /* Optional */ {
                         BlurRadius,
                         FolderColumnsCount,
                         EnableBlurWhenOpenFolder,
-                        EnableFolderIconBlur,
                         SetDeviceLevel,
-                        Dock,
                         ShortcutBlur,
                         UnlockHotseatIcon,
                         TaskViewHorizontal,
@@ -58,6 +57,12 @@ class MainHook : IXposedHookLoadPackage, IXposedHookZygoteInit /* Optional */ {
                         AppDrawer,
                         Recent,
                     )
+                    if (isLegacyAndroid()) {
+                        initHooks(
+                            Dock,
+                            EnableFolderIconBlur,
+                        )
+                    }
                 }
             }
             else -> return
@@ -95,6 +100,4 @@ class MainHook : IXposedHookLoadPackage, IXposedHookZygoteInit /* Optional */ {
             }.logexIfThrow("Failed init hook: ${it.javaClass.simpleName}")
         }
     }
-
-
 }

--- a/app/src/main/java/com/yuk/miuiHomeR/hook/Dock.kt
+++ b/app/src/main/java/com/yuk/miuiHomeR/hook/Dock.kt
@@ -2,10 +2,12 @@ package com.yuk.miuiHomeR.hook
 
 import android.content.Context
 import android.graphics.Color
+import android.os.Build
 import android.os.Bundle
 import android.view.Gravity
 import android.view.View
 import android.widget.FrameLayout
+import androidx.annotation.RequiresApi
 import com.github.kyuubiran.ezxhelper.init.InitFields.appContext
 import com.github.kyuubiran.ezxhelper.utils.hookAllConstructorAfter
 import com.yuk.miuiHomeR.mPrefsMap
@@ -14,6 +16,7 @@ import com.zhenxiang.blur.BlurFrameLayout
 import com.zhenxiang.blur.model.CornersRadius
 import de.robv.android.xposed.XposedHelpers
 
+@RequiresApi(Build.VERSION_CODES.S)
 object Dock : BaseHook() {
     override fun init() {
 
@@ -80,7 +83,10 @@ object Dock : BaseHook() {
             it.result = dp2px(mPrefsMap.getInt("home_dock_top_margin", 30).toFloat())
         }
         "com.miui.home.launcher.DeviceConfig".hookBeforeMethod(
-            "calcHotSeatsMarginBottom", Context::class.java, Boolean::class.java, Boolean::class.java
+            "calcHotSeatsMarginBottom",
+            Context::class.java,
+            Boolean::class.java,
+            Boolean::class.java
         ) {
             it.result = dp2px(mPrefsMap.getInt("home_dock_icon_bottom_margin", -8).toFloat())
         }

--- a/app/src/main/java/com/yuk/miuiHomeR/hook/EnableFolderIconBlur.kt
+++ b/app/src/main/java/com/yuk/miuiHomeR/hook/EnableFolderIconBlur.kt
@@ -1,10 +1,12 @@
 package com.yuk.miuiHomeR.hook
 
 import android.graphics.Color
+import android.os.Build
 import android.view.Gravity
 import android.view.View
 import android.widget.FrameLayout
 import android.widget.ImageView
+import androidx.annotation.RequiresApi
 import com.github.kyuubiran.ezxhelper.init.InitFields
 import com.github.kyuubiran.ezxhelper.utils.findMethod
 import com.github.kyuubiran.ezxhelper.utils.hookAfter
@@ -18,9 +20,9 @@ import com.zhenxiang.blur.BlurFrameLayout
 import com.zhenxiang.blur.model.CornersRadius
 import de.robv.android.xposed.XposedHelpers
 
+@RequiresApi(Build.VERSION_CODES.S)
 object EnableFolderIconBlur : BaseHook() {
     override fun init() {
-
         if (!mPrefsMap.getBoolean("small_folder_blur")) return
         val value = mPrefsMap.getInt("small_folder_corner", 60).toFloat()
         val value1 = mPrefsMap.getInt("small_folder_side", 250)

--- a/app/src/main/java/com/yuk/miuiHomeR/ui/DockActivity.kt
+++ b/app/src/main/java/com/yuk/miuiHomeR/ui/DockActivity.kt
@@ -4,6 +4,7 @@ import androidx.fragment.app.Fragment
 import com.yuk.miuiHomeR.R
 import com.yuk.miuiHomeR.ui.base.BaseAppCompatActivity
 import com.yuk.miuiHomeR.ui.base.SubFragment
+import com.yuk.miuiHomeR.utils.ktx.isLegacyAndroid
 import com.yuk.miuiHomeR.utils.ktx.isPadDevice
 import moralnorm.preference.Preference
 
@@ -20,9 +21,11 @@ class DockActivity : BaseAppCompatActivity() {
 
         override fun initPrefs() {
             val mDockVisible = findPreference<Preference>("prefs_key_home_dock_blur")
-            mDockVisible.isVisible = !isPadDevice()
+            mDockVisible.isVisible = !isPadDevice() && !isLegacyAndroid()
+            mDockVisible.isEnabled = mDockVisible.isVisible
             val mDockTitleVisible = findPreference<Preference>("prefs_key_home_dock_icon_title")
             mDockTitleVisible.isVisible = !isPadDevice()
+            mDockTitleVisible.isEnabled = mDockTitleVisible.isVisible
         }
     }
 }

--- a/app/src/main/java/com/yuk/miuiHomeR/ui/FolderActivity.kt
+++ b/app/src/main/java/com/yuk/miuiHomeR/ui/FolderActivity.kt
@@ -4,6 +4,8 @@ import androidx.fragment.app.Fragment
 import com.yuk.miuiHomeR.R
 import com.yuk.miuiHomeR.ui.base.BaseAppCompatActivity
 import com.yuk.miuiHomeR.ui.base.SubFragment
+import com.yuk.miuiHomeR.utils.ktx.isLegacyAndroid
+import moralnorm.preference.Preference
 
 class FolderActivity : BaseAppCompatActivity() {
 
@@ -16,6 +18,10 @@ class FolderActivity : BaseAppCompatActivity() {
             return R.xml.prefs_folder
         }
 
-        override fun initPrefs() {}
+        override fun initPrefs() {
+            val mSmallFolderBlurVisible = findPreference<Preference>("prefs_key_small_folder_blur")
+            mSmallFolderBlurVisible.isVisible = !isLegacyAndroid()
+            mSmallFolderBlurVisible.isEnabled = mSmallFolderBlurVisible.isVisible
+        }
     }
 }

--- a/app/src/main/java/com/yuk/miuiHomeR/utils/ktx/AppUtil.kt
+++ b/app/src/main/java/com/yuk/miuiHomeR/utils/ktx/AppUtil.kt
@@ -2,6 +2,7 @@ package com.yuk.miuiHomeR.utils.ktx
 
 import android.annotation.SuppressLint
 import android.content.res.Configuration
+import android.os.Build
 import android.util.TypedValue
 import com.github.kyuubiran.ezxhelper.init.InitFields
 import moralnorm.internal.utils.DeviceHelper
@@ -27,6 +28,12 @@ fun getProp(mKey: String): String =
     Class.forName("android.os.SystemProperties").getMethod("get", String::class.java)
         .invoke(Class.forName("android.os.SystemProperties"), mKey).toString()
 
+@SuppressLint("PrivateApi")
+fun getProp(mKey: String, defaultValue: Boolean): Boolean =
+    Class.forName("android.os.SystemProperties")
+        .getMethod("getBoolean", String::class.java, Boolean::class.javaPrimitiveType)
+        .invoke(Class.forName("android.os.SystemProperties"), mKey, defaultValue) as Boolean
+
 fun checkVersionName(): String = InitFields.appContext.packageManager.getPackageInfo(
     InitFields.appContext.packageName, 0
 ).versionName
@@ -36,7 +43,7 @@ fun isAlpha(): Boolean = InitFields.appContext.packageManager.getPackageInfo(
 ).versionName.contains("ALPHA", ignoreCase = true)
 
 fun isPadDevice(): Boolean = DeviceHelper.isTablet() || DeviceHelper.isFoldDevice()
-
+fun isLegacyAndroid(): Boolean = Build.VERSION.SDK_INT < Build.VERSION_CODES.S
 fun checkVersionCode(): Long = InitFields.appContext.packageManager.getPackageInfo(
     InitFields.appContext.packageName, 0
 ).longVersionCode

--- a/app/src/main/java/com/zhenxiang/blur/BackgroundBlurDrawableExtensions.kt
+++ b/app/src/main/java/com/zhenxiang/blur/BackgroundBlurDrawableExtensions.kt
@@ -1,16 +1,21 @@
 package com.zhenxiang.blur
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import com.android.internal.graphics.drawable.BackgroundBlurDrawable
 import org.lsposed.hiddenapibypass.HiddenApiBypass
 
+@RequiresApi(Build.VERSION_CODES.S)
 fun BackgroundBlurDrawable.setColor(color: Int) {
     HiddenApiBypass.invoke(BackgroundBlurDrawable::class.java, this, "setColor", color)
 }
 
+@RequiresApi(Build.VERSION_CODES.S)
 fun BackgroundBlurDrawable.setBlurRadius(blurRadius: Int) {
     HiddenApiBypass.invoke(BackgroundBlurDrawable::class.java, this, "setBlurRadius", blurRadius)
 }
 
+@RequiresApi(Build.VERSION_CODES.S)
 fun BackgroundBlurDrawable.setCornerRadius(
     cornerRadiusTL: Float,
     cornerRadiusTR: Float,

--- a/app/src/main/java/com/zhenxiang/blur/BlurFrameLayout.kt
+++ b/app/src/main/java/com/zhenxiang/blur/BlurFrameLayout.kt
@@ -1,8 +1,11 @@
 package com.zhenxiang.blur
 
 import android.content.Context
+import android.os.Build
 import android.widget.FrameLayout
+import androidx.annotation.RequiresApi
 
 class BlurFrameLayout constructor(context: Context) : FrameLayout(context) {
+    @RequiresApi(Build.VERSION_CODES.S)
     val blurController: SystemBlurController = SystemBlurController(this)
 }

--- a/app/src/main/java/com/zhenxiang/blur/BlurLinearLayout.kt
+++ b/app/src/main/java/com/zhenxiang/blur/BlurLinearLayout.kt
@@ -1,7 +1,11 @@
 package com.zhenxiang.blur
 
 import android.content.Context
+import android.os.Build
 import android.widget.LinearLayout
+import androidx.annotation.RequiresApi
+
 class BlurLinearLayout constructor(context: Context) : LinearLayout(context) {
+    @RequiresApi(Build.VERSION_CODES.S)
     val blurController: SystemBlurController = SystemBlurController(this)
 }

--- a/app/src/main/java/com/zhenxiang/blur/SystemBlurController.kt
+++ b/app/src/main/java/com/zhenxiang/blur/SystemBlurController.kt
@@ -1,6 +1,5 @@
 package com.zhenxiang.blur
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Color
 import android.graphics.drawable.ShapeDrawable
@@ -8,11 +7,13 @@ import android.graphics.drawable.shapes.RoundRectShape
 import android.os.Build
 import android.view.View
 import android.view.WindowManager
+import androidx.annotation.RequiresApi
 import com.android.internal.graphics.drawable.BackgroundBlurDrawable
 import com.yuk.miuiHomeR.mPrefsMap
 import com.zhenxiang.blur.model.CornersRadius
 import java.util.function.Consumer
 
+@RequiresApi(Build.VERSION_CODES.S)
 class SystemBlurController(
     private val view: View,
     backgroundColour: Int = Color.TRANSPARENT,
@@ -62,7 +63,6 @@ class SystemBlurController(
         }
     }
 
-    @SuppressLint("NewApi")
     override fun onViewAttachedToWindow(v: View) {
         windowManager = getWindowManager(view.context).apply {
             blurEnabled = isCrossWindowBlurEnabled
@@ -77,7 +77,6 @@ class SystemBlurController(
         }
     }
 
-    @SuppressLint("NewApi")
     override fun onViewDetachedFromWindow(_v: View) {
         // Clear blur drawable
         if (view.background is BackgroundBlurDrawable) {

--- a/app/src/main/java/com/zhenxiang/blur/ViewExtensions.kt
+++ b/app/src/main/java/com/zhenxiang/blur/ViewExtensions.kt
@@ -1,11 +1,14 @@
 package com.zhenxiang.blur
 
+import android.os.Build
 import android.util.Log
 import android.view.View
 import android.view.ViewRootImpl
+import androidx.annotation.RequiresApi
 import com.android.internal.graphics.drawable.BackgroundBlurDrawable
 import org.lsposed.hiddenapibypass.HiddenApiBypass
 
+@RequiresApi(Build.VERSION_CODES.S)
 fun View.createBackgroundBlurDrawable(): BackgroundBlurDrawable? {
 
     return try {

--- a/hidden-api/build.gradle.kts
+++ b/hidden-api/build.gradle.kts
@@ -22,4 +22,5 @@ android {
 }
 
 dependencies {
+    implementation("androidx.annotation:annotation:1.3.0")
 }

--- a/hidden-api/src/main/java/android/view/ViewRootImpl.java
+++ b/hidden-api/src/main/java/android/view/ViewRootImpl.java
@@ -1,10 +1,14 @@
 package android.view;
 
+import android.os.Build;
+
+import androidx.annotation.RequiresApi;
+
 import com.android.internal.graphics.drawable.BackgroundBlurDrawable;
 
 public class ViewRootImpl {
-
-  public BackgroundBlurDrawable createBackgroundBlurDrawable() {
-    throw new RuntimeException("Stub!");
-  }
+    @RequiresApi(Build.VERSION_CODES.S)
+    public BackgroundBlurDrawable createBackgroundBlurDrawable() {
+        throw new RuntimeException("Stub!");
+    }
 }

--- a/hidden-api/src/main/java/com/android/internal/graphics/drawable/BackgroundBlurDrawable.java
+++ b/hidden-api/src/main/java/com/android/internal/graphics/drawable/BackgroundBlurDrawable.java
@@ -1,7 +1,11 @@
 package com.android.internal.graphics.drawable;
 
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 
+import androidx.annotation.RequiresApi;
+
+@RequiresApi(Build.VERSION_CODES.S)
 public abstract class BackgroundBlurDrawable extends Drawable {
 
 }


### PR DESCRIPTION
Disable the feature that requires Android 12's blur effect API to support Android 11
The following features are disabled on lower version systems:
1. Dock blur
2. Small folder blur